### PR TITLE
Shorten text on about screen so it fits better

### DIFF
--- a/app/views/pages/_about_screen.html.haml
+++ b/app/views/pages/_about_screen.html.haml
@@ -3,8 +3,8 @@
     %p
       Open Hunt is a brand new community for fans and builders of
       early stage technology products. We aim to be <strong>completely open
-      and transparent</strong>, without insiders or gatekeepers who arbitrarily
-      control who gets listed and who gets left out.
+      and transparent</strong>, without insiders or gatekeepers who control
+      who gets listed and who gets left out.
 
     %p
       Our initial design may look similar to another site you know of. This is
@@ -13,9 +13,9 @@
       or submit a <a href="http://github.com/openhunting/openhunt">pull request</a>. We would love your help!
 
     %p
-      This community is just starting and still very fragile.
+      This community is new and still very fragile.
       Please bear with us for the initial bumps and bruises. Our content
-      may be sparse to begin with, but with your support, we can create an
+      may be sparse initially, but with your support, we can create an
       alternative product enthusiast community that lasts.
 
     %p Thank you for your support!
@@ -40,4 +40,3 @@
       %span /
 
       %a(href="https://github.com/openhunting/openhunt") Github Repo
-      %span /


### PR DESCRIPTION
The about screen is a bit tall for a 1280x800 display:

https://cloudup.com/cVnIAorV3Bo

This update makes the copy a tiny bit more concise so it looks better:

https://cloudup.com/cvvme6v67x1

It also removes the trailing `/` in the list of links
