### PR TITLE
Changed feedback message to have more gentle tone

### DIFF
--- a/app/views/projects/_feedback.html.haml
+++ b/app/views/projects/_feedback.html.haml
@@ -25,7 +25,7 @@
     %p
       All <strong>comments go directly to the product owner</strong>, and aren't posted publicly.
 
-    = text_area_tag :body, @feedback.try(:body), class: "form-control", placeholder: "List 3 things you like about this product. ... List 1 thing you hate about it."
+    = text_area_tag :body, @feedback.try(:body), class: "form-control", placeholder: "List 3 things you like about this product. ... List 1 thing you feel it could improve on."
 
     .actions
       - if current_user.present?


### PR DESCRIPTION
The feedback message currently states to list 1 thing the user hates
about the product. The word hate might not encourage positive criticism
so changed it to say '1 thing you feel it could improve on'.
