### PR TITLE
adding close link to top of about modal, for mobile users

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -284,12 +284,18 @@ body
   .about-inner
     max-width: 700px
     margin: auto
-    padding: 30px
+    padding: 40px 30px 30px
     border: 1px solid #aaa
     box-shadow: 0 1px 2px rgba(#000, 0.3)
     border-radius: 3px
     background: rgba(255,255,255, 0.8)
     cursor: default
+    position: relative
+  .close-about--top
+    position: absolute
+    top: 10px
+    right: 20px
+    font-size: 18px
   p
     font-size: 16px
     line-height: 1.7

--- a/app/views/pages/_about_screen.html.haml
+++ b/app/views/pages/_about_screen.html.haml
@@ -1,5 +1,6 @@
 #about-screen{style: local_assigns[:static] ? "" : "display:none;", class: local_assigns[:static] ? "about-static" : "about-dynamic"}
   .about-inner
+    %a.close-about.close-about--top(href="#") Close
     %p
       Open Hunt is a brand new community for fans and builders of
       early stage technology products. We aim to be <strong>completely open


### PR DESCRIPTION
In response to https://github.com/OpenHunting/openhunt/issues/40

I think a "Close" link works better for now than an "X" icon, but certainly open to it

https://www.dropbox.com/s/a5fsjesnexaur4g/Screenshot%202015-12-19%2010.17.34.png?dl=0
