### PR TITLE
Fix for #92

### DIFF
--- a/app-js/components/bucket-scroll.js.es6
+++ b/app-js/components/bucket-scroll.js.es6
@@ -36,6 +36,14 @@
           }
 
           loading = false;
+
+          $('[data-toggle="tooltip"]').tooltip({
+            'animation':false,
+            'delay':0,
+            'placement':'left'
+          });
+
+          console.log("init tooltips")
         },
         error: (xhr) => {
           console.error(xhr);

--- a/app-js/components/bucket-scroll.js.es6
+++ b/app-js/components/bucket-scroll.js.es6
@@ -42,8 +42,7 @@
             'delay':0,
             'placement':'left'
           });
-
-          console.log("init tooltips")
+          
         },
         error: (xhr) => {
           console.error(xhr);


### PR DESCRIPTION
Bootstrap tooltips need to be initialised for dynamic content, according to documentation:

http://getbootstrap.com/javascript/#tooltips

> ### Opt-in functionality
> 
> For performance reasons, the Tooltip and Popover data-apis are opt-in, meaning you must initialize them yourself.
